### PR TITLE
Actually require MSRV in bors

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -62,7 +62,7 @@ jobs:
       - name: Install toolchain
         uses: actions-rs/toolchain@v1
         with:
-          toolchain: nightly-2019-01-01
+          toolchain: nightly-2020-01-01
           profile: minimal
           override: true
 

--- a/bors.toml
+++ b/bors.toml
@@ -2,7 +2,8 @@ cut-body-after = "---"
 delete-merged-branches = true
 
 status = [
-  "Tests",
-  "Rustfmt",
   "Clippy",
+  "MSRV Tests",
+  "Rustfmt",
+  "Tests",
 ]


### PR DESCRIPTION
The previous merge ignored the MSRV tests because I didn't tell bors to check it.

---

bors: r+