### PR TITLE
Soundness fixes

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6,10 +6,17 @@ version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
+name = "either"
+version = "1.5.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+
+[[package]]
 name = "erasable"
 version = "1.0.0-dev"
 dependencies = [
  "autocfg 1.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "either 1.5.3 (registry+https://github.com/rust-lang/crates.io-index)",
+ "scopeguard 1.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -83,6 +90,11 @@ dependencies = [
 ]
 
 [[package]]
+name = "scopeguard"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+
+[[package]]
 name = "slice-dst"
 version = "1.0.0-dev"
 dependencies = [
@@ -107,10 +119,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [metadata]
 "checksum autocfg 1.0.0 (registry+https://github.com/rust-lang/crates.io-index)" = "f8aac770f1885fd7e387acedd76065302551364496e46b3dd00860b2f8359b9d"
+"checksum either 1.5.3 (registry+https://github.com/rust-lang/crates.io-index)" = "bb1f6b1ce1c140482ea30ddd3335fc0024ac7ee112895426e0a629a6c20adfe3"
 "checksum paste 0.1.6 (registry+https://github.com/rust-lang/crates.io-index)" = "423a519e1c6e828f1e73b720f9d9ed2fa643dce8a7737fb43235ce0b41eeaa49"
 "checksum paste-impl 0.1.6 (registry+https://github.com/rust-lang/crates.io-index)" = "4214c9e912ef61bf42b81ba9a47e8aad1b2ffaf739ab162bf96d1e011f54e6c5"
 "checksum proc-macro-hack 0.5.11 (registry+https://github.com/rust-lang/crates.io-index)" = "ecd45702f76d6d3c75a80564378ae228a85f0b59d2f3ed43c91b4a69eb2ebfc5"
 "checksum proc-macro2 1.0.6 (registry+https://github.com/rust-lang/crates.io-index)" = "9c9e470a8dc4aeae2dee2f335e8f533e2d4b347e1434e5671afc49b054592f27"
 "checksum quote 1.0.2 (registry+https://github.com/rust-lang/crates.io-index)" = "053a8c8bcc71fcce321828dc897a98ab9760bef03a4fc36693c231e5b3216cfe"
+"checksum scopeguard 1.0.0 (registry+https://github.com/rust-lang/crates.io-index)" = "b42e15e59b18a828bbf5c58ea01debb36b9b096346de35d941dcb89009f24a0d"
 "checksum syn 1.0.11 (registry+https://github.com/rust-lang/crates.io-index)" = "dff0acdb207ae2fe6d5976617f887eb1e35a2ba52c13c7234c790960cdad9238"
 "checksum unicode-xid 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)" = "826e7639553986605ec5979c7dd957c7895e93eabed50ab2ffa7f6128a75097c"

--- a/crates/erasable/Cargo.toml
+++ b/crates/erasable/Cargo.toml
@@ -18,5 +18,16 @@ maintenance = { status = "passively-maintained" }
 default = ["alloc"]
 alloc = []
 
+[dependencies]
+scopeguard = { version = "1.0.0", default-features = false }
+
+[dev-dependencies]
+either = "1.5.3"
+
 [build-dependencies]
 autocfg = "1.0.0"
+
+[[test]]
+name = "abuse"
+path = "tests/abuse.rs"
+required-features = ["alloc"]

--- a/crates/erasable/src/lib.rs
+++ b/crates/erasable/src/lib.rs
@@ -294,8 +294,6 @@ where
     }
 }
 
-// TODO: SAFETY REVIEW: Is this (and DerefMut) impl actually sound?
-//       We're doing really questionable lifetime hacking.
 impl<P: ErasablePtr> Deref for Thin<P>
 where
     P: Deref,

--- a/crates/erasable/tests/abuse.rs
+++ b/crates/erasable/tests/abuse.rs
@@ -1,0 +1,58 @@
+use {
+    either::{Either, Left, Right},
+    erasable::{ErasablePtr, ErasedPtr, Thin},
+    std::ops::{Deref, DerefMut},
+};
+
+struct MeanestDerefInTheWest {
+    evil: Box<Either<Box<usize>, Box<usize>>>,
+}
+
+impl MeanestDerefInTheWest {
+    fn new() -> Self {
+        MeanestDerefInTheWest {
+            evil: Box::new(Left(Box::new(0))),
+        }
+    }
+}
+
+unsafe impl ErasablePtr for MeanestDerefInTheWest {
+    fn erase(this: Self) -> ErasedPtr {
+        ErasablePtr::erase(this.evil)
+    }
+    unsafe fn unerase(this: ErasedPtr) -> Self {
+        MeanestDerefInTheWest {
+            evil: ErasablePtr::unerase(this),
+        }
+    }
+}
+
+impl Deref for MeanestDerefInTheWest {
+    type Target = usize;
+
+    fn deref(&self) -> &usize {
+        self.evil.as_ref().as_ref().into_inner().as_ref() // LUL
+    }
+}
+
+// this is the interesting/evil bit
+impl DerefMut for MeanestDerefInTheWest {
+    fn deref_mut(&mut self) -> &mut usize {
+        let val = **self;
+        if self.evil.is_left() {
+            self.evil = Box::new(Right(Box::new(val + 1)));
+        } else {
+            self.evil = Box::new(Left(Box::new(val + 1)));
+        }
+        self.evil.as_mut().as_mut().into_inner().as_mut() // LUL
+    }
+}
+
+#[test]
+fn abuse() {
+    let mut mean = Thin::from(MeanestDerefInTheWest::new());
+    for _ in 0..10 {
+        mean.deref_mut();
+    }
+    assert_eq!(*mean, 10);
+}


### PR DESCRIPTION
- `Thin::with_mut` now properly saves changes to the pointer, where it didn't before,
- Properly clarified requirements on `ErasablePtr` types to deref to a distinct location from the pointer itself and not contain pre-indirection shared mutability, and
- Removed unsound `ErasablePtr for ptr::NonNull` impl for unsized `T` -- unerasing is required to have a valid pointer, but we know via blanket impl that the impl for all sized types has the trivial no-read implementation.

---

bors: r+