### PR TITLE
Improve MSRV handling

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -59,24 +59,30 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@v1
 
-      - name: Install toolchain
+      - name: Install nightly toolchain
         uses: actions-rs/toolchain@v1
         with:
           toolchain: nightly-2020-01-01
           profile: minimal
+
+      - name: Install minimum supported stable toolchain
+        uses: actions-rs/toolchain@v1
+        with:
+          toolchain: 1.41.0
+          profile: minimal
           override: true
+
+      - name: Generate lockfile
+        uses: actions-rs/cargo@v1
+        with:
+          command: +nightly-2020-01-01
+          args: -Z generate-lockfile
 
       - name: Cargo target cache
         uses: actions/cache@v1
         with:
           path: target
           key: ${{ runner.os }}-cargo-msrv-target-${{ hashFiles('**/Cargo.lock') }}
-
-      - name: Generate lockfile
-        uses: actions-rs/cargo@v1
-        with:
-          command: -Z
-          args: generate-lockfile
 
       - name: Compile
         uses: actions-rs/cargo@v1


### PR DESCRIPTION
- Generate minimal lockfile _before_ generating cache key
- Do tests on stable 1.41.0; only generate the minimal lockfile on nightly-2020-01-01

---

This is part of the push for 1.0.0 🎉