### PR TITLE
Remove dead code from Thin::from(P)

### DIFF
--- a/crates/erasable/src/lib.rs
+++ b/crates/erasable/src/lib.rs
@@ -201,13 +201,10 @@ unsafe impl<P: ErasablePtr> Sync for Thin<P> where P: Sync {}
 
 impl<P: ErasablePtr> From<P> for Thin<P> {
     fn from(this: P) -> Self {
-        let this = Thin::<P> {
+        Thin::<P> {
             ptr: P::erase(this),
             marker: PhantomData,
-        };
-        Thin::inner(&this);
-        Thin::with(&this, |_| {});
-        this
+        }
     }
 }
 


### PR DESCRIPTION
This is a remnant of debugging,
when I was trying to get miri to fail fast.

---

bors: r+