### PR TITLE
Fix unsoundness around ZSTs in slice-dst

### DIFF
--- a/crates/slice-dst/src/lib.rs
+++ b/crates/slice-dst/src/lib.rs
@@ -125,6 +125,16 @@ pub unsafe trait SliceDst {
     fn retype(ptr: ptr::NonNull<[()]>) -> ptr::NonNull<Self>;
 }
 
+unsafe impl<T> SliceDst for [T] {
+    fn layout_for(len: usize) -> Layout {
+        layout_polyfill::layout_array::<T>(len).unwrap()
+    }
+
+    fn retype(ptr: ptr::NonNull<[()]>) -> ptr::NonNull<Self> {
+        unsafe { ptr::NonNull::new_unchecked(ptr.as_ptr() as *mut _) }
+    }
+}
+
 /// Allocate a slice-based DST with the [global allocator][`alloc()`].
 ///
 /// The returned pointer is owned and completely uninitialized;

--- a/crates/slice-dst/tests/smoke.rs
+++ b/crates/slice-dst/tests/smoke.rs
@@ -3,7 +3,11 @@
 
 #![allow(unused, clippy::redundant_clone)]
 
-use {erasable::Thin, slice_dst::*, std::sync::Arc};
+use {
+    erasable::Thin,
+    slice_dst::*,
+    std::{mem::MaybeUninit, sync::Arc},
+};
 
 #[test]
 fn slice() {
@@ -18,6 +22,13 @@ fn zst() {
     let slice: Vec<()> = vec![(); 16];
     let slice: Box<SliceWithHeader<(), ()>> = SliceWithHeader::new((), slice);
     let slice = slice.clone();
+}
+
+#[test]
+fn actual_zst() {
+    unsafe {
+        let slice: Box<[MaybeUninit<()>]> = Box::new_slice_dst(10, drop);
+    }
 }
 
 type Data = usize;


### PR DESCRIPTION
This also adds `impl SliceDst for [_]` as a very simple way of observing the issue. Allocating a ZST with the global allocator is not allowed; this fixes `alloc_slice_dst_in` to handle the ZST case by returning an arbitrary aligned pointer without touching the global allocator. Fixes #23

r? @danielhenrymantilla