### PR TITLE
Fix msrv tests

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -76,7 +76,7 @@ jobs:
         uses: actions-rs/cargo@v1
         with:
           command: +nightly-2020-01-01
-          args: -Z generate-lockfile
+          args: -Z minimal-versions generate-lockfile
 
       - name: Cargo target cache
         uses: actions/cache@v1

--- a/crates/ptr-union/Cargo.toml
+++ b/crates/ptr-union/Cargo.toml
@@ -21,6 +21,9 @@ alloc = ["erasable/alloc"]
 [dependencies]
 paste = "0.1.6"
 
+# minimal-versions fix dtolnay/paste#15
+proc-macro-hack = "0.5.9"
+
 [dependencies.erasable]
 version = "1.0.0"
 path = "../erasable"


### PR DESCRIPTION
bors: r+

paste is the problematic dependency, pulling in a syn version pre-1.0 via an old proc-macro-hack. https://github.com/dtolnay/paste/pull/15