### PR TITLE
Don't use slice::from_raw_parts for uninitialized memory

### DIFF
--- a/crates/slice-dst/src/lib.rs
+++ b/crates/slice-dst/src/lib.rs
@@ -99,7 +99,7 @@ use {
         alloc::{alloc, dealloc, handle_alloc_error},
         boxed::Box,
     },
-    core::{alloc::Layout, mem::ManuallyDrop, ptr, slice},
+    core::{alloc::Layout, mem::ManuallyDrop, ptr},
 };
 
 /// A custom slice-based dynamically sized type.
@@ -173,7 +173,7 @@ where
             ptr::NonNull::new(alloc(layout) as *mut ())
         }
         .unwrap_or_else(|| handle_alloc_error(layout));
-        let ptr = ptr::NonNull::new_unchecked(slice::from_raw_parts_mut::<()>(ptr.as_ptr(), len));
+        let ptr = ptr::NonNull::new_unchecked(slice_from_raw_parts(ptr.as_ptr(), len));
         S::retype(ptr)
     }
 }


### PR DESCRIPTION
This is a very annoying incorrect usage of `slice::from_raw_parts` rather than `slice_from_raw_parts`.

This is a freshly allocated pointer, and specifically a pointer to uninitialized memory. So (when available) it is sound to use `ptr::slice_from_raw_parts_mut` and _unsound_ to use `slice::from_raw_parts_mut`.

Yay for yanking another version.

bors: r+