### PR TITLE
Actually drop pointers in ptr-union

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -65,7 +65,7 @@ dependencies = [
 
 [[package]]
 name = "ptr-union"
-version = "1.2.0"
+version = "2.0.0-pre"
 dependencies = [
  "autocfg",
  "erasable",

--- a/crates/ptr-union/Cargo.toml
+++ b/crates/ptr-union/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ptr-union"
-version = "1.2.0"
+version = "2.0.0-pre"
 edition = "2018"
 
 authors = ["Christopher Durham (cad97) <cad97@cad97.com>"]

--- a/crates/ptr-union/README.md
+++ b/crates/ptr-union/README.md
@@ -1,6 +1,34 @@
 Pointer union types the size of a pointer
 by storing the tag in the alignment bits.
 
+## Changelist
+
+### 2.0.0
+#### Fixes
+
+- Union types now drop their contents properly. (Whoops!)
+  This is a breaking change for two main reasons:
+
+  - Trait bounds must be added to the union type to have them on `Drop`
+  - `Copy` can no longer be provided for unions of `Copy` pointers,
+    because `Drop` and `Copy` are mutually exclusive.
+
+  I also took this opportunity to clean up the builder proof API a little,
+  as the previous shape was more difficult to use than intended.
+
+#### How did this happen
+
+We do run the test suite for this crate under [miri]. In fact, miri is how the
+leak was diagnosed and ensured to be fixed. However, the test suite previously
+did not actually attempt to drop any pointer union, and the author thought that
+it did. This combination let the lack of a `Drop` impl be overlooked.
+
+#### Using previous versions
+
+In short, you're better off not. However, if you must for some reason,
+make sure that any time you drop a pointer union, you call `unpack`.
+This will ensure that the inner types are properly dropped instead of leaking.
+
 ## Related Crates
 
 - [`erasable`](https://lib.rs/crates/erasable): Erase pointers of their concrete type.

--- a/crates/ptr-union/src/lib.rs
+++ b/crates/ptr-union/src/lib.rs
@@ -10,8 +10,9 @@ use {
         hash::{self, Hash},
         hint::unreachable_unchecked,
         marker::PhantomData,
-        mem::{self, ManuallyDrop},
+        mem::ManuallyDrop,
         ops::Deref,
+        ptr,
     },
     erasable::{ErasablePtr, ErasedPtr},
 };
@@ -41,227 +42,103 @@ fn unset_tag(ptr: ErasedPtr, mask: usize, tag: usize) -> ErasedPtr {
     unsafe { ErasedPtr::new_unchecked((ptr.as_ptr() as usize & !mask) as *mut _) }
 }
 
-// NB: If we get strong const generics eventually, we can provide a safe constructor!
-//     fn new() where A: AlignedPtr<N>, B: AlignedPtr<N>, C: AlignedPtr<N>, D: AlignedPtr<N> {}
-//     unsafe trait AlignedPtr<const N: usize>: ErasablePtr {}
-//     unsafe impl<P: ErasablePtr, const N: usize> AlignedPtr<N> for P where <{align_of::<P::Deref>() >= N}> {}
-/// A builder for pointer unions that enforces correct alignment.
-///
-/// Currently, because there is no way to generically talk about alignment in the type system, this
-/// requires the use of `unsafe` for the programmer to assert that the types are properly aligned.
-/// For that, you get all of the unsafe pointer-wrangling for pointer-sized pointer unions.
-///
-/// In the future, with sufficiently advanced const generics, it might be possible to avoid this.
-pub struct UnionBuilder<U> {
-    private: PhantomData<U>,
-}
-
-impl<U> Copy for UnionBuilder<U> {}
-impl<U> Clone for UnionBuilder<U> {
-    fn clone(&self) -> Self {
-        *self
-    }
-}
-impl<U> fmt::Debug for UnionBuilder<U> {
-    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        f.debug_tuple("UnionBuilder")
-            .field(&format_args!("{}", core::any::type_name::<U>()))
-            .finish()
-    }
-}
-
-impl<A, B> UnionBuilder<Union2<A, B>> {
-    /// Deprecated alias for [`UnionBuilder::new2`].
-    ///
-    /// The name conflicts with [`UnionBuilder::<Union4<_,_,_,_>>::new`](#method.new-1),
-    /// causing use to be more difficult than was desired.
-    #[allow(clippy::missing_safety_doc)]
-    #[deprecated(since = "1.1.0", note = "use `UnionBuilder::new2` instead")]
-    pub const unsafe fn new() -> Self {
-        Self::new2()
-    }
-
-    /// Assert that creating pointer unions of these two types is safe.
-    ///
-    /// # Safety
-    ///
-    /// Both `A` and `B` pointer types must be [erasable](`ErasablePtr`),
-    /// and their erased form must align to at least `u16` (`#[repr(align(2))]`).
-    ///
-    /// # Examples
-    ///
-    /// Sound:
-    ///
-    /// ```rust
-    /// # use ptr_union::*;
-    /// # unsafe {
-    /// UnionBuilder::<Union2<Box<u16>, &u32>>::new2();
-    /// # }
-    /// ```
-    ///
-    /// Unsound:
-    ///
-    /// ```rust
-    /// # use ptr_union::*;
-    /// # unsafe {
-    /// UnionBuilder::<Union2<Box<u16>, &u8>>::new2();
-    /// # }
-    /// ```
-    pub const unsafe fn new2() -> Self {
-        UnionBuilder {
-            private: PhantomData,
+#[cfg(has_never)]
+pub type NeverPtr = !;
+#[cfg(not(has_never))]
+use never_ptr::NeverPtr;
+#[cfg(not(has_never))]
+mod never_ptr {
+    use super::*;
+    #[derive(Debug, Copy, Clone, Ord, PartialOrd, Eq, PartialEq, Hash)]
+    pub enum NeverPtr {}
+    unsafe impl ErasablePtr for NeverPtr {
+        fn erase(this: Self) -> ErasedPtr {
+            match this {}
         }
-    }
-}
-
-impl<A, B, C, D> UnionBuilder<Union4<A, B, C, D>> {
-    /// Deprecated alias for [`UnionBuilder::new4`].
-    ///
-    /// The name conflicts with [`UnionBuilder::<Union2<_,_>>::new`](#method.new),
-    /// causing use to be more difficult than was desired.
-    #[allow(clippy::missing_safety_doc)]
-    #[deprecated(since = "1.1.0", note = "use `UnionBuilder::new4` instead")]
-    pub const unsafe fn new() -> Self {
-        Self::new4()
-    }
-
-    /// Assert that creating pointer unions of these four types is safe.
-    ///
-    /// # Safety
-    ///
-    /// The `A`, `B`, `C`, and `D` pointer types must be [erasable](`ErasablePtr`),
-    /// and their erased form must align to at least `u32` (`#[repr(align(4))]`).
-    ///
-    /// # Examples
-    ///
-    /// Sound:
-    ///
-    /// ```rust
-    /// # use ptr_union::*; use std::sync::Arc;
-    /// # unsafe {
-    /// UnionBuilder::<Union4<Box<u32>, &u32, Arc<u32>, Arc<u64>>>::new4();
-    /// # }
-    /// ```
-    ///
-    /// Unsound:
-    ///
-    /// ```rust
-    /// # use ptr_union::*; use std::sync::Arc;
-    /// # unsafe {
-    /// UnionBuilder::<Union4<Box<u16>, &u16, Arc<u16>, Arc<u64>>>::new4();
-    /// # }
-    /// ```
-    pub const unsafe fn new4() -> Self {
-        UnionBuilder {
-            private: PhantomData,
+        unsafe fn unerase(_this: ErasedPtr) -> Self {
+            unreachable!()
         }
     }
 }
 
 /// A pointer union of two pointer types.
 ///
-/// This is a tagged union of two pointer types such as `Box<T>`, `Arc<T>`, or `&T` that is only as
-/// big as a pointer. This is accomplished by storing the tag in the alignment bits of the pointer.
+/// This is a tagged union of two pointer types such as `Box`, `Arc`, or `&`
+/// that is only as big as a single pointer. This is accomplished by storing
+/// the tag in the alignment bits of the pointer.
 ///
-/// As such, the pointer must be aligned to at least `u16` (`#[repr(align(2))]`).
-/// This is enforced through the use of [`UnionBuilder`].
-pub struct Union2<A, B> {
+/// As such, the pointer must be aligned to at least `u16` (`align(2)`).
+/// This is enforced through the use of [`Builder2`].
+pub struct Union2<A: ErasablePtr, B: ErasablePtr> {
     raw: ErasedPtr,
-    a: PhantomData<A>,
-    b: PhantomData<B>,
+    phantom: PhantomData<Enum2<A, B>>,
 }
 
-/// A pointer union of three or four pointer types.
+/// A pointer union of four pointer types.
 ///
-/// This is a tagged union of three or four pointer types such as `Box<T>`, `Arc<T>`, or `&T` that
-/// is only as big as a pointer. This is accomplished by storing the tag in the alignment bits of
-/// the pointer.
+/// This is a tagged union of four pointer types such as `Box`, `Arc`, or `&`
+/// that is only as big as a single pointer. This is accomplished by storing
+/// the tag in the alignment bits of the pointer.
 ///
-/// As such, the pointer must be aligned to at least `u32` (`#[repr(align(4))]`).
-/// This is enforced through the use of [`UnionBuilder`].
+/// As such, the pointer must be aligned to at least `u32` (`align(4)`).
+/// This is enforced through the use of [`Builder4`].
 ///
-/// The last type may be omitted for a three pointer union.
-/// Just specify a `Union4<A, B, C>` instead of `Union4<A, B, C, D>`.
-/// The used `NeverPtr` type will be changed to `!` once it stabilizes.
+/// The fourth pointer type may be omitted to create a three pointer union.
+/// The default type, `NeverPtr`, will be an alias for `!` once it is stable.
 /// This will not be considered a breaking change.
-pub struct Union4<A, B, C, D = NeverPtr> {
+pub struct Union4<A: ErasablePtr, B: ErasablePtr, C: ErasablePtr, D: ErasablePtr = NeverPtr> {
     raw: ErasedPtr,
-    a: PhantomData<A>,
-    b: PhantomData<B>,
-    c: PhantomData<C>,
-    d: PhantomData<D>,
+    phantom: PhantomData<Enum4<A, B, C, D>>,
 }
 
-impl<A: ErasablePtr, B: ErasablePtr> UnionBuilder<Union2<A, B>> {
-    /// Construct a union at this variant.
-    pub fn a(self, a: A) -> Union2<A, B> {
-        Union2 {
-            raw: set_tag(A::erase(a), MASK_2, TAG_A),
-            a: PhantomData,
-            b: PhantomData,
-        }
-    }
-
-    /// Construct a union at this variant.
-    pub fn b(self, b: B) -> Union2<A, B> {
-        Union2 {
-            raw: set_tag(B::erase(b), MASK_2, TAG_B),
-            a: PhantomData,
-            b: PhantomData,
-        }
-    }
+/// An unpacked version of [`Union2`].
+#[allow(missing_docs)]
+#[derive(Debug, Copy, Clone, Eq, PartialEq, Hash)]
+pub enum Enum2<A, B> {
+    A(A),
+    B(B),
 }
 
-impl<A: ErasablePtr, B: ErasablePtr, C: ErasablePtr, D: ErasablePtr>
-    UnionBuilder<Union4<A, B, C, D>>
-{
-    /// Construct a union at this variant.
-    pub fn a(self, a: A) -> Union4<A, B, C, D> {
-        Union4 {
-            raw: set_tag(A::erase(a), MASK_4, TAG_A),
-            a: PhantomData,
-            b: PhantomData,
-            c: PhantomData,
-            d: PhantomData,
-        }
-    }
-
-    /// Construct a union at this variant.
-    pub fn b(self, b: B) -> Union4<A, B, C, D> {
-        Union4 {
-            raw: set_tag(B::erase(b), MASK_4, TAG_B),
-            a: PhantomData,
-            b: PhantomData,
-            c: PhantomData,
-            d: PhantomData,
-        }
-    }
-
-    /// Construct a union at this variant.
-    pub fn c(self, c: C) -> Union4<A, B, C, D> {
-        Union4 {
-            raw: set_tag(C::erase(c), MASK_4, TAG_C),
-            a: PhantomData,
-            b: PhantomData,
-            c: PhantomData,
-            d: PhantomData,
-        }
-    }
-
-    /// Construct a union at this variant.
-    pub fn d(self, d: D) -> Union4<A, B, C, D> {
-        Union4 {
-            raw: set_tag(D::erase(d), MASK_4, TAG_D),
-            a: PhantomData,
-            b: PhantomData,
-            c: PhantomData,
-            d: PhantomData,
-        }
-    }
+/// An unpacked version of [`Union4`].
+#[allow(missing_docs)]
+#[derive(Debug, Copy, Clone, Eq, PartialEq, Hash)]
+pub enum Enum4<A, B, C, D> {
+    A(A),
+    B(B),
+    C(C),
+    D(D),
 }
 
-macro_rules! union_methods {
-    ($Union:ident: $mask:ident $([$a:ident $A:ident])*) => {
+/// A builder for [`Union2`].
+///
+/// An instance of this builder means that `Union2` parameterized
+/// with the same type arguments are safe to construct.
+pub struct Builder2<A, B> {
+    phantom: PhantomData<Enum2<A, B>>,
+}
+
+/// A builder for [`Union4`].
+///
+/// An instance of this builder means that `Union4` parameterized
+/// with the same type arguments are safe to construct.
+pub struct Builder4<A, B, C, D = NeverPtr> {
+    phantom: PhantomData<Enum4<A, B, C, D>>,
+}
+
+macro_rules! impl_union {
+    ($Union:ident, $Enum:ident, $Builder:ident: $mask:ident $([$a:ident $A:ident])*) => {
+        impl<$($A),*> $Builder<$($A),*> {
+            /// Assert that creating pointer unions of these types is safe.
+            ///
+            /// # Safety
+            ///
+            /// The pointer types must be [erasable](`ErasablePtr`), and their
+            /// alignment must meet the requirements of the target union type.
+            pub const unsafe fn new_unchecked() -> Self {
+                Self { phantom: PhantomData }
+            }
+        }
+
         impl<$($A: ErasablePtr),*> $Union<$($A),*> {
             $(
                 paste::item! {
@@ -276,7 +153,8 @@ macro_rules! union_methods {
                     /// Returns the union on error.
                     pub fn [<into_ $a>](self) -> Result<$A, Self> {
                         if self.[<is_ $a>]() {
-                            unsafe { Ok($A::unerase(unset_tag(self.raw, $mask, [<TAG_ $A>]))) }
+                            let this = ManuallyDrop::new(self);
+                            unsafe { Ok($A::unerase(unset_tag(this.raw, $mask, [<TAG_ $A>]))) }
                         } else {
                             Err(self)
                         }
@@ -287,8 +165,8 @@ macro_rules! union_methods {
                     pub fn [<with_ $a>]<R>(&self, f: impl FnOnce(&$A) -> R) -> Option<R> {
                         if self.[<is_ $a>]() {
                             unsafe {
-                                let $a = ManuallyDrop::new($A::unerase(unset_tag(self.raw, $mask, [<TAG_ $A>])));
-                                Some(f(&$a))
+                                let this = ManuallyDrop::new($A::unerase(unset_tag(self.raw, $mask, [<TAG_ $A>])));
+                                Some(f(&this))
                             }
                         } else {
                             None
@@ -298,43 +176,31 @@ macro_rules! union_methods {
                 paste::item! {
                     /// Get a reference to this variant's target.
                     pub fn $a(&self) -> Option<&$A::Target>
-                    where
-                        $A: Deref,
+                    where $A: Deref
                     {
-                        self.[<with_ $a>](|$a| unsafe { erase_lt(&**$a) })
+                        self.[<with_ $a>](|this| unsafe { erase_lt(&**this) })
                     }
                 }
                 paste::item! {
                     /// Clone this variant out of the union.
                     pub fn [<clone_ $a>](&self) -> Option<$A>
-                    where
-                        $A: Clone,
+                    where $A: Clone
                     {
-                        self.[<with_ $a>](|$a| $a.clone() )
+                        self.[<with_ $a>](|this| this.clone())
                     }
                 }
                 paste::item! {
                     /// Copy this variant out of the union.
                     pub fn [<copy_ $a>](&self) -> Option<$A>
-                    where
-                        $A: Copy,
+                    where $A: Copy
                     {
-                        self.[<with_ $a>](|$a| *$a)
+                        self.[<with_ $a>](|this| *this)
                     }
                 }
             )*
 
-            /// NB: Not safe generally!
-            /// Because `as_deref_unchecked` only requires the actual reference is aligned.
-            /// So it can be used for overaligned &T where not all &T are aligned enough.
-            #[allow(deprecated)]
-            unsafe fn builder(&self) -> UnionBuilder<Self> {
-                UnionBuilder::<Self>::new()
-            }
-
-            /// Check if two `Union`s are the same variant
-            /// and point to the same value
-            /// (not that the values compare as equal).
+            /// Check if two unions are the same variant and point to
+            /// the same value (not that the values compare as equal).
             pub fn ptr_eq(&self, other: &Self) -> bool {
                 self.raw == other.raw
             }
@@ -342,17 +208,61 @@ macro_rules! union_methods {
             /// Dereference the current pointer.
             pub fn as_deref<'a>(
                 &'a self,
-                proof: UnionBuilder<$Union<$(&'a $A::Target),*>>,
+                builder: $Builder<$(&'a $A::Target),*>
             ) -> $Union<$(&'a $A::Target),*>
             where
                 $($A: Deref,)*
                 $(&'a $A::Target: ErasablePtr,)*
             {
-                $(if let Some($a) = self.$a() {
-                    proof.$a($a)
+                $(if let Some(this) = self.$a() {
+                    builder.$a(this)
                 } else)* {
                     unsafe { unreachable_unchecked() }
                 }
+            }
+
+            /// Dereference the current pointer.
+            ///
+            /// # Safety
+            ///
+            /// The reference produced must be properly aligned. Note that only
+            /// the actually produced reference is restricted, not the result
+            /// of dereferencing any of the other types in this union.
+            pub unsafe fn as_deref_unchecked<'a>(&'a self) -> $Union<$(&'a $A::Target),*>
+            where
+                $($A: Deref,)*
+                $(&'a $A::Target: ErasablePtr,)*
+            {
+                self.as_deref($Builder::new_unchecked())
+            }
+
+            paste::item! {
+                /// Unpack this union into an enum.
+                pub fn unpack(self) -> $Enum<$($A),*> {
+                    Err(self)
+                        $(.or_else(|this| this.[<into_ $a>]().map($Enum::$A)))*
+                        .unwrap_or_else(|_| unsafe { unreachable_unchecked() })
+                }
+            }
+        }
+
+        impl<$($A: ErasablePtr),*> $Enum<$($A),*> {
+            /// Pack this loose enum into a pointer union.
+            pub fn pack(self, builder: $Builder<$($A),*>) -> $Union<$($A),*> {
+                match self {
+                    $($Enum::$A(this) => builder.$a(this),)*
+                }
+            }
+
+            /// Pack this loose enum into a pointer union.
+            ///
+            /// # Safety
+            ///
+            /// The pointer packed must be properly aligned. Note that only
+            /// the actually packed pointer is restricted, not any other
+            /// pointer type involved in this definition.
+            pub unsafe fn pack_unchecked(self) -> $Union<$($A),*> {
+                self.pack($Builder::new_unchecked())
             }
         }
 
@@ -364,88 +274,26 @@ macro_rules! union_methods {
             unsafe fn unerase(this: ErasedPtr) -> Self {
                 Self {
                     raw: this,
-                    $($a: PhantomData,)*
+                    phantom: PhantomData,
                 }
             }
         }
-    };
-}
 
-union_methods!(Union2: MASK_2 [a A] [b B]);
-union_methods!(Union4: MASK_4 [a A] [b B] [c C] [d D]);
+        impl<$($A: ErasablePtr),*> Drop for $Union<$($A),*> {
+            fn drop(&mut self) {
+                unsafe { drop(ptr::read(self).unpack()) }
+            }
+        }
 
-impl<A: ErasablePtr, B: ErasablePtr> Union2<A, B> {
-    // NB: This function is defined outside the macro for specialized documentation.
-    /// Dereference the current pointer.
-    ///
-    /// # Safety
-    ///
-    /// The reference produced by dereferencing must align to at least `u16` (2 bytes).
-    pub unsafe fn as_deref_unchecked<'a>(&'a self) -> Union2<&'a A::Target, &'a B::Target>
-    where
-        A: Deref,
-        B: Deref,
-        &'a A::Target: ErasablePtr,
-        &'a B::Target: ErasablePtr,
-    {
-        self.as_deref(UnionBuilder::new2())
-    }
-
-    /// Unpack this union into an enum.
-    pub fn unpack(self) -> Enum2<A, B> {
-        Err(self)
-            .or_else(|this| this.into_a().map(Enum2::A))
-            .or_else(|this| this.into_b().map(Enum2::B))
-            .unwrap_or_else(|_| unsafe { unreachable_unchecked() })
-    }
-}
-
-impl<A: ErasablePtr, B: ErasablePtr, C: ErasablePtr, D: ErasablePtr> Union4<A, B, C, D> {
-    // NB: This function is defined outside the macro for specialized documentation.
-    /// Dereference the current pointer.
-    ///
-    /// # Safety
-    ///
-    /// The reference produced by dereferencing must align to at least `u32` (4 bytes).
-    pub unsafe fn as_deref_unchecked<'a>(
-        &'a self,
-    ) -> Union4<&'a A::Target, &'a B::Target, &'a C::Target, &'a D::Target>
-    where
-        A: Deref,
-        B: Deref,
-        C: Deref,
-        D: Deref,
-        &'a A::Target: ErasablePtr,
-        &'a B::Target: ErasablePtr,
-        &'a C::Target: ErasablePtr,
-        &'a D::Target: ErasablePtr,
-    {
-        self.as_deref(UnionBuilder::new4())
-    }
-
-    /// Unpack this union into an enum.
-    pub fn unpack(self) -> Enum4<A, B, C, D> {
-        Err(self)
-            .or_else(|this| this.into_a().map(Enum4::A))
-            .or_else(|this| this.into_b().map(Enum4::B))
-            .or_else(|this| this.into_c().map(Enum4::C))
-            .or_else(|this| this.into_d().map(Enum4::D))
-            .unwrap_or_else(|_| unsafe { unreachable_unchecked() })
-    }
-}
-
-macro_rules! union_traits {
-    ($Union:ident $([$a:ident $A:ident])*) => {
         impl<$($A: ErasablePtr),*> fmt::Debug for $Union<$($A),*>
-        where
-            $($A: fmt::Debug,)*
+        where $($A: fmt::Debug),*
         {
             paste::item! {
                 fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
                     None
-                        $(.or_else(|| self.[<with_ $a>](|$a| f
-                            .debug_tuple(concat!(stringify!($Union), "::", stringify!($A)))
-                            .field($a)
+                        $(.or_else(|| self.[<with_ $a>](|this| f
+                            .debug_tuple(stringify!($A))
+                            .field(this)
                             .finish()
                         )))*
                         .unwrap_or_else(|| unsafe { unreachable_unchecked() })
@@ -453,16 +301,14 @@ macro_rules! union_traits {
             }
         }
 
-        impl<$($A: ErasablePtr),*> Copy for $Union<$($A),*> where $($A: Copy,)* {}
         impl<$($A: ErasablePtr),*> Clone for $Union<$($A),*>
-        where
-            $($A: Clone,)*
+        where $($A: Clone),*
         {
             paste::item! {
                 fn clone(&self) -> Self {
-                    let builder = unsafe { self.builder() };
+                    let builder = unsafe { <$Builder<$($A,)*>>::new_unchecked() };
                     None
-                        $(.or_else(|| self.[<clone_ $a>]().map(|$a| builder.$a($a))))*
+                        $(.or_else(|| self.[<clone_ $a>]().map(|this| builder.$a(this))))*
                         .unwrap_or_else(|| unsafe { unreachable_unchecked() })
                 }
             }
@@ -470,8 +316,7 @@ macro_rules! union_traits {
 
         impl<$($A: ErasablePtr,)*> Eq for $Union<$($A),*> where $($A: Eq,)* {}
         impl<$($A: ErasablePtr),*> PartialEq for $Union<$($A),*>
-        where
-            $($A: PartialEq,)*
+        where $($A: PartialEq),*
         {
             paste::item! {
                 fn eq(&self, other: &Self) -> bool {
@@ -487,104 +332,119 @@ macro_rules! union_traits {
         }
 
         impl<$($A: ErasablePtr,)*> Hash for $Union<$($A),*>
-        where
-            $($A: Hash,)*
+        where $($A: Hash),*
         {
             paste::item! {
                 fn hash<H>(&self, state: &mut H)
-                where
-                    H: hash::Hasher
+                where H: hash::Hasher
                 {
                     None
-                        $(.or_else(|| self.[<with_ $a>](|$a| $a.hash(state))))*
+                        $(.or_else(|| self.[<with_ $a>](|this| this.hash(state))))*
                         .unwrap_or_else(|| unsafe { unreachable_unchecked() })
                 }
             }
         }
+
+        unsafe impl<$($A: ErasablePtr,)*> Send for $Union<$($A),*> where $($A: Send),* {}
+        unsafe impl<$($A: ErasablePtr,)*> Sync for $Union<$($A),*> where $($A: Sync),* {}
     };
 }
 
-union_traits!(Union2 [a A] [b B]);
-union_traits!(Union4 [a A] [b B] [c C] [d D]);
+impl_union!(Union2, Enum2, Builder2: MASK_2 [a A] [b B]);
+impl_union!(Union4, Enum4, Builder4: MASK_4 [a A] [b B] [c C] [d D]);
+
+impl<A: ErasablePtr, B: ErasablePtr> Builder2<A, B> {
+    /// Construct a union at this variant.
+    pub fn a(self, this: A) -> Union2<A, B> {
+        Union2 {
+            raw: set_tag(A::erase(this), MASK_2, TAG_A),
+            phantom: PhantomData,
+        }
+    }
+
+    /// Construct a union at this variant.
+    pub fn b(self, this: B) -> Union2<A, B> {
+        Union2 {
+            raw: set_tag(B::erase(this), MASK_2, TAG_B),
+            phantom: PhantomData,
+        }
+    }
+}
+
+impl<A: ErasablePtr, B: ErasablePtr, C: ErasablePtr, D: ErasablePtr> Builder4<A, B, C, D> {
+    /// Construct a union at this variant.
+    pub fn a(self, this: A) -> Union4<A, B, C, D> {
+        Union4 {
+            raw: set_tag(A::erase(this), MASK_4, TAG_A),
+            phantom: PhantomData,
+        }
+    }
+
+    /// Construct a union at this variant.
+    pub fn b(self, this: B) -> Union4<A, B, C, D> {
+        Union4 {
+            raw: set_tag(B::erase(this), MASK_4, TAG_B),
+            phantom: PhantomData,
+        }
+    }
+
+    /// Construct a union at this variant.
+    pub fn c(self, this: C) -> Union4<A, B, C, D> {
+        Union4 {
+            raw: set_tag(C::erase(this), MASK_4, TAG_C),
+            phantom: PhantomData,
+        }
+    }
+
+    /// Construct a union at this variant.
+    pub fn d(self, this: D) -> Union4<A, B, C, D> {
+        Union4 {
+            raw: set_tag(D::erase(this), MASK_4, TAG_D),
+            phantom: PhantomData,
+        }
+    }
+}
+
+impl<A, B> fmt::Debug for Builder2<A, B> {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.debug_tuple("Builder2")
+            .field(&format_args!(
+                "Union2<{}, {}>",
+                core::any::type_name::<A>(),
+                core::any::type_name::<B>(),
+            ))
+            .finish()
+    }
+}
+
+impl<A, B> Copy for Builder2<A, B> {}
+impl<A, B> Clone for Builder2<A, B> {
+    fn clone(&self) -> Self {
+        *self
+    }
+}
+
+impl<A, B, C, D> fmt::Debug for Builder4<A, B, C, D> {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.debug_tuple("Builder4")
+            .field(&format_args!(
+                "Union4<{}, {}, {}, {}>",
+                core::any::type_name::<A>(),
+                core::any::type_name::<B>(),
+                core::any::type_name::<C>(),
+                core::any::type_name::<D>(),
+            ))
+            .finish()
+    }
+}
+
+impl<A, B, C, D> Copy for Builder4<A, B, C, D> {}
+impl<A, B, C, D> Clone for Builder4<A, B, C, D> {
+    fn clone(&self) -> Self {
+        *self
+    }
+}
 
 unsafe fn erase_lt<'a, 'b, T: ?Sized>(r: &'a T) -> &'b T {
-    mem::transmute(r)
-}
-
-#[cfg(not(has_never))]
-use priv_in_pub::NeverPtr;
-#[cfg(not(has_never))]
-mod priv_in_pub {
-    use super::*;
-
-    #[derive(Debug, Copy, Clone, Ord, PartialOrd, Eq, PartialEq, Hash)]
-    pub enum NeverPtr {}
-    unsafe impl ErasablePtr for NeverPtr {
-        fn erase(_: Self) -> ErasedPtr {
-            unreachable!()
-        }
-        unsafe fn unerase(_: ErasedPtr) -> Self {
-            unreachable!()
-        }
-    }
-}
-#[cfg(has_never)]
-pub type NeverPtr = !;
-
-/// An unpacked version of [`Union2`].
-#[allow(missing_docs)]
-#[derive(Debug, Copy, Clone, Eq, PartialEq, Hash)]
-pub enum Enum2<A, B> {
-    A(A),
-    B(B),
-}
-
-/// An unpacked version of [`Union4`].
-#[allow(missing_docs)]
-#[derive(Debug, Copy, Clone, Eq, PartialEq, Hash)]
-pub enum Enum4<A, B, C, D = NeverPtr> {
-    A(A),
-    B(B),
-    C(C),
-    D(D),
-}
-
-impl<A: ErasablePtr, B: ErasablePtr> Enum2<A, B> {
-    /// Pack this loose enum into a pointer union.
-    pub fn pack(self, proof: UnionBuilder<Union2<A, B>>) -> Union2<A, B> {
-        match self {
-            Enum2::A(a) => proof.a(a),
-            Enum2::B(b) => proof.b(b),
-        }
-    }
-
-    /// Pack this loose enum into a pointer union.
-    ///
-    /// # Safety
-    ///
-    /// The used pointer must align to at least `u16` (`#[repr(align(2))]`).
-    pub unsafe fn pack_unchecked(self) -> Union2<A, B> {
-        self.pack(UnionBuilder::new2())
-    }
-}
-
-impl<A: ErasablePtr, B: ErasablePtr, C: ErasablePtr, D: ErasablePtr> Enum4<A, B, C, D> {
-    /// Pack this loose enum into a pointer union.
-    pub fn pack(self, proof: UnionBuilder<Union4<A, B, C, D>>) -> Union4<A, B, C, D> {
-        match self {
-            Enum4::A(a) => proof.a(a),
-            Enum4::B(b) => proof.b(b),
-            Enum4::C(c) => proof.c(c),
-            Enum4::D(d) => proof.d(d),
-        }
-    }
-
-    /// Pack this loose enum into a pointer union.
-    ///
-    /// # Safety
-    ///
-    /// The used pointer must align to at least `u32` (`#[repr(align(4))]`).
-    pub unsafe fn pack_unchecked(self) -> Union4<A, B, C, D> {
-        self.pack(UnionBuilder::new4())
-    }
+    &*(r as *const T)
 }

--- a/crates/ptr-union/tests/smoke.rs
+++ b/crates/ptr-union/tests/smoke.rs
@@ -32,6 +32,11 @@ const BIG_UNION_PROOF_4: UnionBuilder<Union4<Box<BigA>, Box<BigB>, Box<BigC>, Bo
     unsafe { UnionBuilder::new4() };
 
 #[test]
+fn smoke() {
+    let a = BIG_UNION_PROOF_2.a(Default::default());
+}
+
+#[test]
 fn smoke2() {
     let a = BIG_UNION_PROOF_2.a(Default::default());
     let b = BIG_UNION_PROOF_2.b(Default::default());

--- a/crates/ptr-union/tests/smoke.rs
+++ b/crates/ptr-union/tests/smoke.rs
@@ -1,15 +1,9 @@
 //! These tests don't really assert anything, they just exercise the API.
 //! This is primarily intended to be run under miri as a sanitizer.
 
-#![allow(
-    unused,
-    clippy::redundant_clone,
-    clippy::borrowed_box,
-    clippy::type_complexity,
-    clippy::drop_ref
-)]
+#![allow(clippy::borrowed_box, clippy::drop_ref)]
 
-use ptr_union::{Union2, Union4, UnionBuilder};
+use ptr_union::{Builder2, Builder4};
 
 #[repr(align(4))]
 #[derive(Debug, Default, Clone)]
@@ -24,16 +18,23 @@ struct BigC([u128; 16]);
 #[derive(Debug, Default, Clone)]
 struct BigD([u128; 16]);
 
-const BIG_UNION_PROOF_2: UnionBuilder<Union2<Box<BigA>, Box<BigB>>> =
-    unsafe { UnionBuilder::new2() };
-const BIG_UNION_PROOF_3: UnionBuilder<Union4<Box<BigA>, Box<BigB>, Box<BigC>>> =
-    unsafe { UnionBuilder::new4() };
-const BIG_UNION_PROOF_4: UnionBuilder<Union4<Box<BigA>, Box<BigB>, Box<BigC>, Box<BigD>>> =
-    unsafe { UnionBuilder::new4() };
+const BIG_UNION_PROOF_2: Builder2<Box<BigA>, Box<BigB>> = unsafe { Builder2::new_unchecked() };
+const BIG_UNION_PROOF_3: Builder4<Box<BigA>, Box<BigB>, Box<BigC>> =
+    unsafe { Builder4::new_unchecked() };
+const BIG_UNION_PROOF_4: Builder4<Box<BigA>, Box<BigB>, Box<BigC>, Box<BigD>> =
+    unsafe { Builder4::new_unchecked() };
 
 #[test]
 fn smoke() {
-    let a = BIG_UNION_PROOF_2.a(Default::default());
+    let _ = BIG_UNION_PROOF_2.a(Default::default());
+    let _ = BIG_UNION_PROOF_2.b(Default::default());
+    let _ = BIG_UNION_PROOF_3.a(Default::default());
+    let _ = BIG_UNION_PROOF_3.b(Default::default());
+    let _ = BIG_UNION_PROOF_3.c(Default::default());
+    let _ = BIG_UNION_PROOF_4.a(Default::default());
+    let _ = BIG_UNION_PROOF_4.b(Default::default());
+    let _ = BIG_UNION_PROOF_4.c(Default::default());
+    let _ = BIG_UNION_PROOF_4.d(Default::default());
 }
 
 #[test]


### PR DESCRIPTION
Found thanks to miri. `Union2`/`Union4` were accidentally missing a `Drop` impl, and so did not drop their wrapped pointers when dropped.

This snuck through testing because no pointer unions were actually dropped in the tests, so miri could not find any leaks, because nothing did leak. I, unfortunately, did not realize this.

I'm going to publish this as a `-pre` version just in case I run into any more issues with this API that I want to fix while polishing `sorbus`.

bors: r+