### PR TITLE
Add [A]RcBorrow -> Weak conversion without strong clone

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -14,7 +14,7 @@ checksum = "bb1f6b1ce1c140482ea30ddd3335fc0024ac7ee112895426e0a629a6c20adfe3"
 
 [[package]]
 name = "erasable"
-version = "1.2.0"
+version = "1.2.1"
 dependencies = [
  "autocfg",
  "either",
@@ -23,9 +23,9 @@ dependencies = [
 
 [[package]]
 name = "erasable"
-version = "1.2.0"
+version = "1.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c18404d99ecdee16598948437ef1a18b94c74f4d3a374cd41f642626c2c57cd8"
+checksum = "5f11890ce181d47a64e5d1eb4b6caba0e7bae911a356723740d058a5d0340b7d"
 dependencies = [
  "autocfg",
  "scopeguard",
@@ -33,9 +33,9 @@ dependencies = [
 
 [[package]]
 name = "paste"
-version = "0.1.10"
+version = "0.1.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ab4fb1930692d1b6a9cfabdde3d06ea0a7d186518e2f4d67660d8970e2fa647a"
+checksum = "678f27e19361472a23717f11d229a7522ef64605baf0715c896a94b8b6b13a06"
 dependencies = [
  "paste-impl",
  "proc-macro-hack",
@@ -43,9 +43,9 @@ dependencies = [
 
 [[package]]
 name = "paste-impl"
-version = "0.1.10"
+version = "0.1.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a62486e111e571b1e93b710b61e8f493c0013be39629b714cb166bdb06aa5a8a"
+checksum = "149089128a45d8e377677b08873b4bad2a56618f80e4f28a83862ba250994a30"
 dependencies = [
  "proc-macro-hack",
  "proc-macro2",
@@ -55,56 +55,51 @@ dependencies = [
 
 [[package]]
 name = "proc-macro-hack"
-version = "0.5.11"
+version = "0.5.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ecd45702f76d6d3c75a80564378ae228a85f0b59d2f3ed43c91b4a69eb2ebfc5"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn",
-]
+checksum = "7e0456befd48169b9f13ef0f0ad46d492cf9d2dbb918bcf38e01eed4ce3ec5e4"
 
 [[package]]
 name = "proc-macro2"
-version = "1.0.8"
+version = "1.0.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3acb317c6ff86a4e579dfa00fc5e6cca91ecbb4e7eb2df0468805b674eb88548"
+checksum = "1502d12e458c49a4c9cbff560d0fe0060c252bc29799ed94ca2ed4bb665a0101"
 dependencies = [
  "unicode-xid",
 ]
 
 [[package]]
 name = "ptr-union"
-version = "2.0.0"
+version = "2.0.1"
 dependencies = [
  "autocfg",
- "erasable 1.2.0",
+ "erasable 1.2.1",
  "paste",
 ]
 
 [[package]]
 name = "quote"
-version = "1.0.2"
+version = "1.0.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "053a8c8bcc71fcce321828dc897a98ab9760bef03a4fc36693c231e5b3216cfe"
+checksum = "54a21852a652ad6f610c9510194f398ff6f8692e334fd1145fed931f7fbe44ea"
 dependencies = [
  "proc-macro2",
 ]
 
 [[package]]
 name = "rc-borrow"
-version = "1.2.0"
+version = "1.2.1"
 dependencies = [
  "autocfg",
- "erasable 1.2.0",
+ "erasable 1.2.1",
 ]
 
 [[package]]
 name = "rc-box"
-version = "1.1.0"
+version = "1.1.1"
 dependencies = [
- "erasable 1.2.0",
- "slice-dst 1.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "erasable 1.2.1",
+ "slice-dst 1.4.1 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -115,27 +110,27 @@ checksum = "d29ab0c6d3fc0ee92fe66e2d99f700eab17a8d57d1c1d3b748380fb20baa78cd"
 
 [[package]]
 name = "slice-dst"
-version = "1.4.0"
+version = "1.4.1"
 dependencies = [
  "autocfg",
- "erasable 1.2.0",
+ "erasable 1.2.1",
 ]
 
 [[package]]
 name = "slice-dst"
-version = "1.4.0"
+version = "1.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bf8103682684791d9a6db538a391935eccd438b723d08017418ae0d07e91c1d7"
+checksum = "9fad5402bd04a3a3209ee22a021be871f54519bf427f50d4d2c9e19ab11f7d36"
 dependencies = [
  "autocfg",
- "erasable 1.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "erasable 1.2.1 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
 name = "syn"
-version = "1.0.15"
+version = "1.0.24"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7a0294dc449adc58bb6592fff1a23d3e5e6e235afc6a0ffca2657d19e7bbffe5"
+checksum = "f87bc5b2815ebb664de0392fdf1b95b6d10e160f86d9f64ff65e5679841ca06a"
 dependencies = [
  "proc-macro2",
  "quote",

--- a/crates/rc-borrow/build.rs
+++ b/crates/rc-borrow/build.rs
@@ -1,8 +1,0 @@
-fn main() {
-    let cfg = autocfg::new();
-    cfg.emit_expression_cfg("std::sync::Arc::as_raw", "has_Arc__into_raw");
-    cfg.emit_expression_cfg("std::sync::Arc::clone_raw", "has_Arc__clone_raw");
-    cfg.emit_expression_cfg("std::rc::Rc::as_raw", "has_Rc__into_raw");
-    cfg.emit_expression_cfg("std::rc::Rc::clone_raw", "has_Rc__clone_raw");
-    autocfg::rerun_path("build.rs");
-}


### PR DESCRIPTION
```rust
pub fn $RcBorrow<'_, T>::to_weak(Self) -> $rc::Weak<T>;
```

Also includes a `cargo update` and adjusts removes unneccessary use of autocfg.

-----

Closes #58, cc @yvt: do you have any other suggestions for what this method should be called?

If I could go back in time, it would be `$RcBorrow::upgrade(Self) -> $Rc`, `$RcBorrow::downgrade(Self) -> $Weak`, and `$RcBorrow::extend(Self) -> &'a T`, but that ship has sailed.

It might still be worth it to deprecate `downgrade` and replace it with `extend` or some other better name, as [`downgrade` does not match context, where the point is to get a longer-lived reference](https://github.com/CAD97/rust-analyzer/pull/2/files#diff-d23193d1e5a20e45ff7c807273433cc9R31).