### PR TITLE
Allow deprecated in polyfills

### DIFF
--- a/crates/slice-dst/src/layout_polyfill.rs
+++ b/crates/slice-dst/src/layout_polyfill.rs
@@ -1,3 +1,5 @@
+#![allow(deprecated)] // this is a polyfill module
+
 use core::{
     alloc::{Layout, LayoutErr},
     cmp,


### PR DESCRIPTION
The whole point is to polyfill functionality on older rustc versions, so we need to use the deprecated `LayoutErr` rather than the new, more proper name of `LayoutError`.

---

bors: r+
🤖