### PR TITLE
Improve ptr-union's behavior under strict provenance

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -41,7 +41,7 @@ checksum = "0744126afe1a6dd7f394cb50a716dbe086cb06e255e53d8d0185d82828358fb5"
 
 [[package]]
 name = "ptr-union"
-version = "2.2.1"
+version = "2.2.2"
 dependencies = [
  "autocfg",
  "erasable 1.2.1",

--- a/crates/ptr-union/Cargo.toml
+++ b/crates/ptr-union/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ptr-union"
-version = "2.2.1"
+version = "2.2.2"
 edition = "2018"
 
 authors = ["Christopher Durham (cad97) <cad97@cad97.com>"]

--- a/crates/ptr-union/README.md
+++ b/crates/ptr-union/README.md
@@ -3,6 +3,16 @@ by storing the tag in the alignment bits.
 
 ## Changelist
 
+### 2.2.2
+#### Fixed
+
+- Crate now works under a [strict provenance] model. (In short, it doesn't use inttoptr.)
+- Crate is now tested with many more strictness Miri flags. Notably,
+  - `-Zmiri-check-number-validity` and
+  - `-Zmiri-tag-raw-pointers`
+
+[strict provenance]: https://github.com/rust-lang/rust/issues/95228
+
 ### 2.2.0
 #### Added
 


### PR DESCRIPTION
-----

Let's try this again now with less typos

bors: r+ 🤖 