### PR TITLE
Add 'with()' and 'with_mut()' as associated functions to ErasedPtr

### DIFF
--- a/crates/erasable/src/lib.rs
+++ b/crates/erasable/src/lib.rs
@@ -201,6 +201,7 @@ pub unsafe trait ErasablePtr {
     /// };
     ///
     /// assert_eq!(*cloned, 123);
+    /// # unsafe {<Rc<i32> as ErasablePtr>::unerase(erased)}; // drop it
     /// ```
     ///
     /// The main purpose of this function is to be able implement recursive types that would
@@ -215,7 +216,7 @@ pub unsafe trait ErasablePtr {
         Self: Sized,
         F: FnOnce(&Self) -> T,
     {
-        f(&ManuallyDrop::new(&Self::unerase(*this)))
+        f(&ManuallyDrop::new(Self::unerase(*this)))
     }
 
     /// Run a closure on a mutable borrow of the real pointer.  Unlike the `Thin<T>` wrapper

--- a/crates/erasable/src/lib.rs
+++ b/crates/erasable/src/lib.rs
@@ -185,6 +185,54 @@ pub unsafe trait ErasablePtr {
     ///
     /// The erased pointer must have been created by `erase`.
     unsafe fn unerase(this: ErasedPtr) -> Self;
+
+    /// Run a closure on a borrow of the real pointer.  Unlike the `Thin<T>` wrapper this does
+    /// not carry the original type around. Thus it is required to specify the original impl
+    /// type when calling this function.
+    ///
+    /// ```
+    /// # use {erasable::*, std::rc::Rc};
+    /// let rc: Rc<i32> = Rc::new(123);
+    ///
+    /// let erased: ErasedPtr = ErasablePtr::erase(rc);
+    ///
+    /// let cloned = unsafe {
+    ///     <Rc<i32> as ErasablePtr>::with(&erased, |rc| rc.clone())
+    /// };
+    ///
+    /// assert_eq!(*cloned, 123);
+    /// ```
+    ///
+    /// The main purpose of this function is to be able implement recursive types that would
+    /// be otherwise not representable in rust.
+    ///
+    /// # Safety
+    ///
+    ///  * The erased pointer must have been created by `erase`.
+    ///  * The specified impl type must be the original type.
+    unsafe fn with<F, T>(this: &ErasedPtr, f: F) -> T
+    where
+        Self: Sized,
+        F: FnOnce(&Self) -> T,
+    {
+        f(&ManuallyDrop::new(&Self::unerase(*this)))
+    }
+
+    /// Run a closure on a mutable borrow of the real pointer.  Unlike the `Thin<T>` wrapper
+    /// this does not carry the original type around. Thus it is required to specify the
+    /// original impl type when calling this function.
+    ///
+    /// # Safety
+    ///
+    ///  * The erased pointer must have been created by `erase`.
+    ///  * The specified impl type must be the original type.
+    unsafe fn with_mut<F, T>(this: &mut ErasedPtr, f: F) -> T
+    where
+        Self: Sized,
+        F: FnOnce(&mut Self) -> T,
+    {
+        f(&mut ManuallyDrop::new(&mut Self::unerase(*this)))
+    }
 }
 
 /// A pointee type that supports type-erased pointers (thin pointers).

--- a/crates/erasable/tests/smoke.rs
+++ b/crates/erasable/tests/smoke.rs
@@ -71,7 +71,7 @@ fn with_mut_fn_replacethis() {
     let boxed: Box<Big> = Default::default();
 
     let mut erased: ErasedPtr = ErasablePtr::erase(boxed);
-    let e1 = erased.as_ptr() as usize;
+    let e1 = erased.as_ptr();
     unsafe {
         <Box<Big> as ErasablePtr>::with_mut(&mut erased, |bigbox| {
             let mut newboxed: Box<Big> = Default::default();
@@ -81,7 +81,7 @@ fn with_mut_fn_replacethis() {
         })
     }
 
-    let e2 = erased.as_ptr() as usize;
+    let e2 = erased.as_ptr();
     assert_ne!(e1, e2);
 
     // drop it, otherwise we would leak memory here

--- a/crates/erasable/tests/smoke.rs
+++ b/crates/erasable/tests/smoke.rs
@@ -61,4 +61,29 @@ fn with_mut_fn() {
             assert_ne!(*bigbox, Default::default());
         })
     }
+
+    // drop it, otherwise we would leak memory here
+    unsafe { <Box<Big> as ErasablePtr>::unerase(erased) };
+}
+
+#[test]
+fn with_mut_fn_replacethis() {
+    let boxed: Box<Big> = Default::default();
+
+    let mut erased: ErasedPtr = ErasablePtr::erase(boxed);
+    let e1 = erased.as_ptr() as usize;
+    unsafe {
+        <Box<Big> as ErasablePtr>::with_mut(&mut erased, |bigbox| {
+            let mut newboxed: Box<Big> = Default::default();
+            newboxed.0[0] = 123456;
+            *bigbox = newboxed;
+            assert_ne!(*bigbox, Default::default());
+        })
+    }
+
+    let e2 = erased.as_ptr() as usize;
+    assert_ne!(e1, e2);
+
+    // drop it, otherwise we would leak memory here
+    unsafe { <Box<Big> as ErasablePtr>::unerase(erased) };
 }

--- a/crates/erasable/tests/smoke.rs
+++ b/crates/erasable/tests/smoke.rs
@@ -34,7 +34,7 @@ fn thinning() {
 }
 
 #[test]
-fn withfn() {
+fn with_fn() {
     let boxed: Box<Big> = Default::default();
 
     let erased: ErasedPtr = ErasablePtr::erase(boxed);
@@ -44,6 +44,9 @@ fn withfn() {
             assert_eq!(*bigbox, Default::default());
         })
     }
+
+    // drop it, otherwise we would leak memory here
+    unsafe { <Box<Big> as ErasablePtr>::unerase(erased) };
 }
 
 #[test]

--- a/crates/erasable/tests/smoke.rs
+++ b/crates/erasable/tests/smoke.rs
@@ -32,3 +32,30 @@ fn thinning() {
     Thin::with_mut(&mut thin, |thin| *thin = Default::default());
     let boxed = Thin::into_inner(thin);
 }
+
+#[test]
+fn withfn() {
+    let boxed: Box<Big> = Default::default();
+
+    let erased: ErasedPtr = ErasablePtr::erase(boxed);
+
+    unsafe {
+        <Box<Big> as ErasablePtr>::with(&erased, |bigbox| {
+            assert_eq!(*bigbox, Default::default());
+        })
+    }
+}
+
+#[test]
+fn with_mut_fn() {
+    let boxed: Box<Big> = Default::default();
+
+    let mut erased: ErasedPtr = ErasablePtr::erase(boxed);
+
+    unsafe {
+        <Box<Big> as ErasablePtr>::with_mut(&mut erased, |bigbox| {
+            bigbox.0[0] = 123456;
+            assert_ne!(*bigbox, Default::default());
+        })
+    }
+}


### PR DESCRIPTION
This allows one to use ErasedPtr where rust won't allow a typed reference. For example in recursive types.