### PR TITLE
derive PartialOrd + Ord for SliceWithHeader and StrWithHeader

### DIFF
--- a/crates/slice-dst/src/provided_types.rs
+++ b/crates/slice-dst/src/provided_types.rs
@@ -1,7 +1,9 @@
+use core::cmp::Ordering;
+
 use super::*;
 
 #[repr(C)]
-#[derive(Debug, Eq, PartialEq, PartialOrd, Ord, Hash)]
+#[derive(Debug, Eq, PartialEq, Hash)]
 /// A custom slice-based DST.
 ///
 /// The length is stored as a `usize` at offset 0.
@@ -174,8 +176,28 @@ unsafe impl<Header, Item> Erasable for SliceWithHeader<Header, Item> {
     const ACK_1_1_0: bool = true;
 }
 
+impl<Header, Item> PartialOrd for SliceWithHeader<Header, Item>
+where
+    Header: PartialOrd,
+    Item: PartialOrd,
+{
+    fn partial_cmp(&self, other: &Self) -> Option<Ordering> {
+        (&self.header, &self.slice).partial_cmp(&(&other.header, &other.slice))
+    }
+}
+
+impl<Header, Item> Ord for SliceWithHeader<Header, Item>
+where
+    Header: Ord,
+    Item: Ord,
+{
+    fn cmp(&self, other: &Self) -> Ordering {
+        (&self.header, &self.slice).cmp(&(&other.header, &other.slice))
+    }
+}
+
 #[repr(C)]
-#[derive(Debug, Eq, PartialEq, PartialOrd, Ord, Hash)]
+#[derive(Debug, Eq, PartialEq, Hash)]
 /// A custom str-based DST.
 ///
 /// The length is stored as a `usize` at offset 0.
@@ -245,4 +267,22 @@ unsafe impl<Header> Erasable for StrWithHeader<Header> {
     }
 
     const ACK_1_1_0: bool = true;
+}
+
+impl<Header> PartialOrd for StrWithHeader<Header>
+where
+    Header: PartialOrd,
+{
+    fn partial_cmp(&self, other: &Self) -> Option<Ordering> {
+        (&self.header, &self.str).partial_cmp(&(&other.header, &other.str))
+    }
+}
+
+impl<Header> Ord for StrWithHeader<Header>
+where
+    Header: Ord,
+{
+    fn cmp(&self, other: &Self) -> Ordering {
+        (&self.header, &self.str).cmp(&(&other.header, &other.str))
+    }
 }

--- a/crates/slice-dst/src/provided_types.rs
+++ b/crates/slice-dst/src/provided_types.rs
@@ -1,7 +1,7 @@
 use super::*;
 
 #[repr(C)]
-#[derive(Debug, Eq, PartialEq, Hash)]
+#[derive(Debug, Eq, PartialEq, PartialOrd, Ord, Hash)]
 /// A custom slice-based DST.
 ///
 /// The length is stored as a `usize` at offset 0.
@@ -175,7 +175,7 @@ unsafe impl<Header, Item> Erasable for SliceWithHeader<Header, Item> {
 }
 
 #[repr(C)]
-#[derive(Debug, Eq, PartialEq, Hash)]
+#[derive(Debug, Eq, PartialEq, PartialOrd, Ord, Hash)]
 /// A custom str-based DST.
 ///
 /// The length is stored as a `usize` at offset 0.

--- a/crates/slice-dst/tests/smoke.rs
+++ b/crates/slice-dst/tests/smoke.rs
@@ -61,20 +61,20 @@ fn str_eq_cmp() {
         assert_ne!(l, r);
         assert_ne!(r, l);
 
-        assert_eq!(l <= l, lt <= lt);
-        assert_eq!(l >= l, lt >= lt);
+        assert_eq!(l <= l, lt <= lt, "{lt:?} <= {lt:?}");
+        assert_eq!(l >= l, lt >= lt, "{lt:?} >= {lt:?}");
 
-        assert_eq!(l < l, lt < lt);
-        assert_eq!(l > l, lt > lt);
+        assert_eq!(l < l, lt < lt, "{lt:?} < {lt:?}");
+        assert_eq!(l > l, lt > lt, "{lt:?} > {lt:?}");
 
-        assert_eq!(r <= r, rt <= rt);
-        assert_eq!(r >= r, rt >= rt);
+        assert_eq!(r <= r, rt <= rt, "{rt:?} <= {rt:?}");
+        assert_eq!(r >= r, rt >= rt, "{rt:?} >= {rt:?}");
 
-        assert_eq!(r < r, rt < rt);
-        assert_eq!(r > r, rt > rt);
+        assert_eq!(r < r, rt < rt, "{rt:?} < {rt:?}");
+        assert_eq!(r > r, rt > rt, "{rt:?} > {rt:?}");
 
-        assert_eq!(l < r, lt < rt);
-        assert_eq!(r > l, rt > lt);
+        assert_eq!(l < r, lt < rt, "{lt:?} < {rt:?}");
+        assert_eq!(r > l, rt > lt, "{rt:?} > {lt:?}");
     })
 }
 
@@ -98,20 +98,57 @@ fn slice_eq_cmp() {
         assert_ne!(l, r);
         assert_ne!(r, l);
 
-        assert_eq!(l <= l, lt <= lt);
-        assert_eq!(l >= l, lt >= lt);
+        assert_eq!(l <= l, lt <= lt, "{lt:?} <= {lt:?}");
+        assert_eq!(l >= l, lt >= lt, "{lt:?} >= {lt:?}");
 
-        assert_eq!(l < l, lt < lt);
-        assert_eq!(l > l, lt > lt);
+        assert_eq!(l < l, lt < lt, "{lt:?} < {lt:?}");
+        assert_eq!(l > l, lt > lt, "{lt:?} > {lt:?}");
 
-        assert_eq!(r <= r, rt <= rt);
-        assert_eq!(r >= r, rt >= rt);
+        assert_eq!(r <= r, rt <= rt, "{rt:?} <= {rt:?}");
+        assert_eq!(r >= r, rt >= rt, "{rt:?} >= {rt:?}");
 
-        assert_eq!(r < r, rt < rt);
-        assert_eq!(r > r, rt > rt);
+        assert_eq!(r < r, rt < rt, "{rt:?} < {rt:?}");
+        assert_eq!(r > r, rt > rt, "{rt:?} > {rt:?}");
 
-        assert_eq!(l < r, lt < rt);
-        assert_eq!(r > l, rt > lt);
+        assert_eq!(l < r, lt < rt, "{lt:?} < {rt:?}");
+        assert_eq!(r > l, rt > lt, "{rt:?} > {lt:?}");
+    })
+}
+
+#[test]
+fn slice_partial_eq_cmp() {
+    [
+        [(0.0, &[0.0, 0.0][..]), (1.0, &[0.0, 0.0][..])],
+        [(1.0, &[0.0, 0.0][..]), (0.0, &[0.0, 0.0][..])],
+        [(0.0, &[0.0][..]), (0.0, &[0.0, 0.0][..])],
+        [(0.0, &[0.0, 0.0][..]), (0.0, &[0.0][..])],
+        [(0.0, &[1.0, 2.0][..]), (0.0, &[10.0, 20.0][..])],
+    ]
+    .iter()
+    .for_each(|[lt @ (lh, ls), rt @ (rh, rs)]| {
+        let l: Box<SliceWithHeader<f32, f32>> = SliceWithHeader::from_slice(*lh, ls);
+        let r: Box<SliceWithHeader<f32, f32>> = SliceWithHeader::from_slice(*rh, rs);
+
+        assert_eq!(l, l);
+        assert_eq!(r, r);
+
+        assert_ne!(l, r);
+        assert_ne!(r, l);
+
+        assert_eq!(l <= l, lt <= lt, "{lt:?} <= {lt:?}");
+        assert_eq!(l >= l, lt >= lt, "{lt:?} >= {lt:?}");
+
+        assert_eq!(l < l, lt < lt, "{lt:?} < {lt:?}");
+        assert_eq!(l > l, lt > lt, "{lt:?} > {lt:?}");
+
+        assert_eq!(r <= r, rt <= rt, "{rt:?} <= {rt:?}");
+        assert_eq!(r >= r, rt >= rt, "{rt:?} >= {rt:?}");
+
+        assert_eq!(r < r, rt < rt, "{rt:?} < {rt:?}");
+        assert_eq!(r > r, rt > rt, "{rt:?} > {rt:?}");
+
+        assert_eq!(l < r, lt < rt, "{lt:?} < {rt:?}");
+        assert_eq!(r > l, rt > lt, "{rt:?} > {lt:?}");
     })
 }
 

--- a/crates/slice-dst/tests/smoke.rs
+++ b/crates/slice-dst/tests/smoke.rs
@@ -41,52 +41,78 @@ fn actual_zst() {
 
 #[test]
 fn str_eq_cmp() {
-    let l: Box<StrWithHeader<char>> = StrWithHeader::new('*', "AB");
-    let r: Box<StrWithHeader<char>> = StrWithHeader::new('*', "ab");
+    [
+        [("*", "AB"), ("*", "ab")],
+        [("*", "AB"), ("*", "a")],
+        [("*", "A"), ("*", "ab")],
+        [("A", "*"), ("a", "*")],
+        [("a", "*"), ("A", "*")],
+        [("AB", "*"), ("a", "*")],
+        [("A", "*"), ("ab", "*")],
+    ]
+    .iter()
+    .for_each(|[lt @ (lh, ls), rt @ (rh, rs)]| {
+        let l: Box<StrWithHeader<&str>> = StrWithHeader::new(*lh, ls);
+        let r: Box<StrWithHeader<&str>> = StrWithHeader::new(*rh, rs);
 
-    assert_eq!(l, l);
-    assert_eq!(r, r);
+        assert_eq!(l, l);
+        assert_eq!(r, r);
 
-    assert_ne!(l, r);
-    assert_ne!(r, l);
+        assert_ne!(l, r);
+        assert_ne!(r, l);
 
-    assert!(l <= l);
-    assert!(l >= l);
-    assert!(!(l < l));
-    assert!(!(l > l));
+        assert_eq!(l <= l, lt <= lt);
+        assert_eq!(l >= l, lt >= lt);
 
-    assert!(r <= r);
-    assert!(r >= r);
-    assert!(!(r < r));
-    assert!(!(r > r));
+        assert_eq!(l < l, lt < lt);
+        assert_eq!(l > l, lt > lt);
 
-    assert!(l < r);
-    assert!(r > l);
+        assert_eq!(r <= r, rt <= rt);
+        assert_eq!(r >= r, rt >= rt);
+
+        assert_eq!(r < r, rt < rt);
+        assert_eq!(r > r, rt > rt);
+
+        assert_eq!(l < r, lt < rt);
+        assert_eq!(r > l, rt > lt);
+    })
 }
 
 #[test]
 fn slice_eq_cmp() {
-    let l: Box<SliceWithHeader<i32, i32>> = SliceWithHeader::from_slice(1, &[2, 3]);
-    let r: Box<SliceWithHeader<i32, i32>> = SliceWithHeader::from_slice(10, &[20, 30]);
+    [
+        [(0, &[0, 0][..]), (1, &[0, 0][..])],
+        [(1, &[0, 0][..]), (0, &[0, 0][..])],
+        [(0, &[0][..]), (0, &[0, 0][..])],
+        [(0, &[0, 0][..]), (0, &[0][..])],
+        [(0, &[1, 2][..]), (0, &[10, 20][..])],
+    ]
+    .iter()
+    .for_each(|[lt @ (lh, ls), rt @ (rh, rs)]| {
+        let l: Box<SliceWithHeader<i32, i32>> = SliceWithHeader::from_slice(*lh, ls);
+        let r: Box<SliceWithHeader<i32, i32>> = SliceWithHeader::from_slice(*rh, rs);
 
-    assert_eq!(l, l);
-    assert_eq!(r, r);
+        assert_eq!(l, l);
+        assert_eq!(r, r);
 
-    assert_ne!(l, r);
-    assert_ne!(r, l);
+        assert_ne!(l, r);
+        assert_ne!(r, l);
 
-    assert!(l <= l);
-    assert!(l >= l);
-    assert!(!(l < l));
-    assert!(!(l > l));
+        assert_eq!(l <= l, lt <= lt);
+        assert_eq!(l >= l, lt >= lt);
 
-    assert!(r <= r);
-    assert!(r >= r);
-    assert!(!(r < r));
-    assert!(!(r > r));
+        assert_eq!(l < l, lt < lt);
+        assert_eq!(l > l, lt > lt);
 
-    assert!(l < r);
-    assert!(r > l);
+        assert_eq!(r <= r, rt <= rt);
+        assert_eq!(r >= r, rt >= rt);
+
+        assert_eq!(r < r, rt < rt);
+        assert_eq!(r > r, rt > rt);
+
+        assert_eq!(l < r, lt < rt);
+        assert_eq!(r > l, rt > lt);
+    })
 }
 
 const fn is_partial_ord<T: ?Sized + PartialOrd>() {}

--- a/crates/slice-dst/tests/smoke.rs
+++ b/crates/slice-dst/tests/smoke.rs
@@ -39,6 +39,68 @@ fn actual_zst() {
     }
 }
 
+#[test]
+fn str_eq_cmp() {
+    let l: Box<StrWithHeader<char>> = StrWithHeader::new('*', "AB");
+    let r: Box<StrWithHeader<char>> = StrWithHeader::new('*', "ab");
+
+    assert_eq!(l, l);
+    assert_eq!(r, r);
+
+    assert_ne!(l, r);
+    assert_ne!(r, l);
+
+    assert!(l <= l);
+    assert!(l >= l);
+    assert!(!(l < l));
+    assert!(!(l > l));
+
+    assert!(r <= r);
+    assert!(r >= r);
+    assert!(!(r < r));
+    assert!(!(r > r));
+
+    assert!(l < r);
+    assert!(r > l);
+}
+
+#[test]
+fn slice_eq_cmp() {
+    let l: Box<SliceWithHeader<i32, i32>> = SliceWithHeader::from_slice(1, &[2, 3]);
+    let r: Box<SliceWithHeader<i32, i32>> = SliceWithHeader::from_slice(10, &[20, 30]);
+
+    assert_eq!(l, l);
+    assert_eq!(r, r);
+
+    assert_ne!(l, r);
+    assert_ne!(r, l);
+
+    assert!(l <= l);
+    assert!(l >= l);
+    assert!(!(l < l));
+    assert!(!(l > l));
+
+    assert!(r <= r);
+    assert!(r >= r);
+    assert!(!(r < r));
+    assert!(!(r > r));
+
+    assert!(l < r);
+    assert!(r > l);
+}
+
+const fn is_partial_ord<T: ?Sized + PartialOrd>() {}
+const fn is_ord<T: ?Sized + Ord>() {}
+
+// compile-time check that PartialOrd/Ord is correctly derived
+const _: () = is_partial_ord::<SliceWithHeader<f64, f64>>();
+const _: () = is_partial_ord::<SliceWithHeader<f64, u64>>();
+const _: () = is_partial_ord::<SliceWithHeader<u64, f64>>();
+const _: () = is_ord::<SliceWithHeader<u64, u64>>();
+
+const _: () = is_partial_ord::<StrWithHeader<f64>>();
+const _: () = is_ord::<StrWithHeader<u64>>();
+
 type Data = usize;
 #[repr(transparent)]
 #[derive(Debug, Clone)]


### PR DESCRIPTION
Hi :wave:

As per the title, this PR derives `PartialOrd` and `Ord`
traits for `SliceWithHeader` and `StrWithHeader` types.